### PR TITLE
Updated service classes to use create and update methods instead of save; User-Cat relationship improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9070,9 +9070,9 @@
       }
     },
     "typeorm": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.37.tgz",
-      "integrity": "sha512-7rkW0yCgFC24I5T0f3S/twmLSuccPh1SQmxET/oDWn2sSDVzbyWdnItSdKy27CdJGTlKHYtUVeOcMYw5LRsXVw==",
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.38.tgz",
+      "integrity": "sha512-M6Y3KQcAREQcphOVJciywf4mv6+A0I/SeR+lWNjKsjnQ+a3XcMwGYMGL0Jonsx3H0Cqlf/3yYqVki1jIXSK/xg==",
       "requires": {
         "@sqltools/formatter": "^1.2.2",
         "app-root-path": "^3.0.0",
@@ -9134,9 +9134,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "yargs": {
-          "version": "17.1.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-          "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+          "version": "17.2.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
+          "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "sqlite3": "^5.0.2",
-    "typeorm": "^0.2.37",
+    "typeorm": "^0.2.38",
     "uuid": ">=7"
   },
   "dependenciesComments": {

--- a/src/cats/entities/cat.entity.spec.ts
+++ b/src/cats/entities/cat.entity.spec.ts
@@ -1,0 +1,168 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
+import { buildSampleCat } from '../../../test/helpers/catHelpers';
+import { clearAllTables } from '../../../test/helpers/repositoryHelpers';
+import { buildSampleUser } from '../../../test/helpers/userHelpers';
+import { AppModule } from '../../app/app.module';
+import { InvalidEntityException } from '../../app/exceptions/invalid-entity.exception';
+import { UsersService } from '../../users/providers/users.service';
+import { CatsService } from '../providers/cats.service';
+import { Cat } from './cat.entity';
+
+describe('Cat', () => {
+  let app: INestApplication;
+  let catRepository: Repository<Cat>;
+  let cat: Cat;
+  let catsService: CatsService;
+  let usersService: UsersService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    catRepository = moduleRef.get<Repository<Cat>>(getRepositoryToken(Cat));
+    catsService = moduleRef.get<CatsService>(CatsService);
+    usersService = moduleRef.get<UsersService>(UsersService);
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await clearAllTables(catRepository.manager.connection);
+    cat = buildSampleCat();
+    const user = buildSampleUser();
+    await usersService.create(user);
+    cat.user = user;
+  });
+
+  describe('user relation', () => {
+    describe('when a user has been assigned to the Cat', () => {
+      it('persists that relationship to the datastore', async () => {
+        await catsService.create(cat);
+        const retrievedCat = await catsService.find(cat.id, true);
+        expect(retrievedCat.user.id).toBe(cat.user.id);
+      });
+    });
+
+    describe('when a user has not been assigned to the cat', () => {
+      it('throws an error', async () => {
+        cat.user = undefined;
+        await expect(catsService.create(cat)).rejects.toThrow(QueryFailedError);
+      });
+    });
+  });
+
+  describe('on create', () => {
+    beforeEach(() => {
+      jest.spyOn(cat, 'validateInstance');
+    });
+
+    it('calls validateInstance', async () => {
+      await catsService.create(cat);
+      expect(cat.validateInstance).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('on update', () => {
+    beforeEach(async () => {
+      await catsService.create(cat);
+      jest.spyOn(cat, 'validateInstance');
+    });
+
+    it('calls validateInstance', async () => {
+      cat.name = 'Whiskers von Cattington';
+      await catsService.update(cat);
+      expect(cat.validateInstance).toHaveBeenCalledTimes(1);
+    });
+
+    describe('when a string id is provided', () => {
+      it('does not throw an error when id can be coerced to an integer', async () => {
+        // @ts-ignore - Force typescript to allow assignment of any test value here
+        cat.id = '99';
+        await expect(catsService.update(cat)).resolves.not.toThrow();
+      });
+
+      it('throws an error when the id cannot be coerced to an integer', async () => {
+        // @ts-ignore - Force typescript to allow assignment of any test value here
+        cat.id = 'banana';
+        await expect(catsService.update(cat)).rejects.toThrow(QueryFailedError);
+      });
+    });
+  });
+
+  describe('#validateInstance', () => {
+    describe('when name is invalid', () => {
+      const invalidValues = [
+        undefined,
+        'a string that is longer than..........................................................max allowed length!',
+        true,
+      ];
+
+      invalidValues.forEach((invalidValue) => {
+        it(`throws an error when name is: ${invalidValue} (${typeof (invalidValue)})`, async () => {
+          // @ts-ignore - Force typescript to allow assignment of any test value here
+          cat.name = invalidValue;
+          await expect(cat.validateInstance()).rejects.toThrow(InvalidEntityException);
+        });
+      });
+    });
+
+    describe('when weight is invalid', () => {
+      const invalidValues = [
+        undefined,
+        -5,
+        0,
+        0.4,
+        '9999',
+        'some string',
+      ];
+
+      invalidValues.forEach((invalidValue) => {
+        it(`throws an error when weight is: ${invalidValue} (${typeof (invalidValue)})`, async () => {
+          // @ts-ignore - Force typescript to allow assignment of any test value here
+          cat.weight = invalidValue;
+          await expect(cat.validateInstance()).rejects.toThrow(InvalidEntityException);
+        });
+      });
+    });
+
+    describe('when breed is invalid', () => {
+      const invalidValues = [
+        undefined,
+        'a string that is longer than..........................................................max allowed length!',
+        true,
+      ];
+
+      invalidValues.forEach((invalidValue) => {
+        it(`throws an error when breed is: ${invalidValue} (${typeof (invalidValue)})`, async () => {
+          // @ts-ignore - Force typescript to allow assignment of any test value here
+          cat.breed = invalidValue;
+          await expect(cat.validateInstance()).rejects.toThrow(InvalidEntityException);
+        });
+      });
+    });
+
+    describe('when isFriendly is invalid', () => {
+      const invalidValues = [
+        undefined,
+        'true',
+        'some string',
+      ];
+
+      invalidValues.forEach((invalidValue) => {
+        it(`throws an error when isFriendly is: ${invalidValue} (${typeof (invalidValue)})`, async () => {
+          // @ts-ignore - Force typescript to allow assignment of any test value here
+          cat.isFriendly = invalidValue;
+          await expect(cat.validateInstance()).rejects.toThrow(InvalidEntityException);
+        });
+      });
+    });
+  });
+});

--- a/src/cats/entities/cat.entity.ts
+++ b/src/cats/entities/cat.entity.ts
@@ -2,7 +2,7 @@ import {
   IsBoolean, IsInt, IsNotEmpty, IsPositive, IsString, MaxLength, validate,
 } from 'class-validator';
 import {
-  Entity, Column, PrimaryGeneratedColumn, ObjectIdColumn, BeforeInsert, BeforeUpdate, ManyToOne,
+  Entity, Column, PrimaryGeneratedColumn, ManyToOne,
 } from 'typeorm';
 import { InvalidEntityException } from '../../app/exceptions/invalid-entity.exception';
 // eslint-disable-next-line import/no-cycle
@@ -18,8 +18,6 @@ interface CatOptions {
 
 @Entity()
 export class Cat {
-  @BeforeInsert()
-  @BeforeUpdate()
   async validateInstance() {
     const validationErrors = await validate(this);
     if (validationErrors.length) {
@@ -32,7 +30,6 @@ export class Cat {
     Object.keys(options).forEach((key) => { this[key] = options[key]; });
   }
 
-  @ObjectIdColumn()
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -59,6 +56,6 @@ export class Cat {
   @IsNotEmpty()
   isFriendly: boolean;
 
-  @ManyToOne(() => User, (user) => user.cats)
-  user: Promise<User>;
+  @ManyToOne(() => User, (user) => user.cats, { nullable: false, onDelete: 'CASCADE' })
+  user: User;
 }

--- a/src/cats/providers/cats.service.ts
+++ b/src/cats/providers/cats.service.ts
@@ -1,34 +1,52 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { EntityCreationError, EntityUpdateError } from '../../errors/errors';
 import { Cat } from '../entities/cat.entity';
 
 @Injectable()
 export class CatsService {
   constructor(@InjectRepository(Cat) private catRepository: Repository<Cat>) {}
 
-  async findAll(): Promise<Cat[]> {
-    return this.catRepository.find({ order: { id: 'ASC' } });
+  async findAll(includeOwner: boolean = false): Promise<Cat[]> {
+    return this.catRepository.find({
+      order: { id: 'ASC' },
+      relations: includeOwner ? ['user'] : undefined,
+    });
   }
 
-  async find(id: number): Promise<Cat> {
-    return this.catRepository.findOne(id);
+  async find(id: number, includeOwner: boolean = false): Promise<Cat> {
+    return this.catRepository.findOne(id, {
+      relations: includeOwner ? ['user'] : undefined,
+    });
   }
 
   async exists(id: number): Promise<boolean> {
     return (await this.find(id)) !== undefined;
   }
 
-  async save(cat: Cat): Promise<Cat> {
+  async create(cat: Cat): Promise<Cat> {
+    if (cat.id) {
+      throw new EntityCreationError('Not allowed to specify an id for a new cat.');
+    }
+    await cat.validateInstance();
+    return this.catRepository.save(cat);
+  }
+
+  async update(cat: Cat): Promise<Cat> {
+    if (!cat.id) {
+      throw new EntityUpdateError('Unable to update a cat without an id.');
+    }
+    await cat.validateInstance();
     return this.catRepository.save(cat);
   }
 
   async delete(id: number) {
-    this.catRepository.delete(id);
+    await this.catRepository.delete(id);
   }
 
   async deleteAll() {
-    this.catRepository.clear();
+    await this.catRepository.clear();
   }
 
   async findRandomId(): Promise<number> {

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -1,0 +1,11 @@
+/* eslint-disable max-classes-per-file */
+
+export class CatManagerError extends Error {
+  constructor(...args: any) {
+    super(...args);
+    this.name = this.constructor.name;
+  }
+}
+
+export class EntityCreationError extends CatManagerError {}
+export class EntityUpdateError extends CatManagerError {}

--- a/src/users/dto/replace-user.dto.ts
+++ b/src/users/dto/replace-user.dto.ts
@@ -1,7 +1,0 @@
-import { IsValidPassword } from '../../custom-validator-decorators/IsValidPassword';
-import { BaseUserDto } from './base-user.dto';
-
-export class ReplaceUserDto extends BaseUserDto {
-  @IsValidPassword(true)
-  password: string;
-}

--- a/src/users/entities/user.entity.spec.ts
+++ b/src/users/entities/user.entity.spec.ts
@@ -1,15 +1,72 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import * as bcrypt from 'bcryptjs';
+import { Repository } from 'typeorm';
 import { sampleSalt, samplePassword, sampleEncryptedPassword } from '../../../test/helpers/bcryptHelpers';
+import { buildSampleCats } from '../../../test/helpers/catHelpers';
+import { clearAllTables } from '../../../test/helpers/repositoryHelpers';
+import { buildSampleUser } from '../../../test/helpers/userHelpers';
+import { AppModule } from '../../app/app.module';
+import { InvalidEntityException } from '../../app/exceptions/invalid-entity.exception';
+import { Cat } from '../../cats/entities/cat.entity';
+import { CatsService } from '../../cats/providers/cats.service';
+import { UsersService } from '../providers/users.service';
 import { User } from './user.entity';
 
 describe('User', () => {
+  let app: INestApplication;
+  let userRepository: Repository<User>;
+  let usersService: UsersService;
+  let catsService: CatsService;
+  let user: User;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    userRepository = moduleRef.get<Repository<User>>(getRepositoryToken(User));
+    usersService = moduleRef.get<UsersService>(UsersService);
+    catsService = moduleRef.get<CatsService>(CatsService);
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await clearAllTables(userRepository.manager.connection);
+    user = buildSampleUser();
+  });
+
+  describe('on save (create or update)', () => {
+    let cats: Cat[];
+
+    beforeEach(async () => {
+      cats = buildSampleCats();
+      user.cats = cats;
+      await usersService.create(user);
+    });
+
+    it('cascades the save to any new Cat instances assigned to the cats field (and saves the new cats)', async () => {
+      expect(cats.filter((cat) => cat.id !== undefined)).toHaveLength(cats.length);
+    });
+
+    it('persists all User-Cat relationships to the datastore', async () => {
+      const retrievedUser = await usersService.find(user.id, true);
+      expect(retrievedUser.cats.map((cat) => cat.id).sort()).toEqual(cats.map((cat) => cat.id).sort());
+    });
+  });
+
   describe('#setPassword', () => {
     beforeEach(() => {
       jest.spyOn(bcrypt, 'genSaltSync').mockImplementation((_rounds) => sampleSalt);
     });
 
     it('sets encryptedPassword to the expected value', () => {
-      const user = new User();
       user.setPassword(samplePassword, samplePassword);
 
       expect(user.encryptedPassword).toEqual(sampleEncryptedPassword);
@@ -20,15 +77,46 @@ describe('User', () => {
     const nonMatchingPassword = 'not-banana';
 
     it('returns true for an expected password match', () => {
-      const user = new User();
       user.encryptedPassword = sampleEncryptedPassword;
       expect(user.isPasswordMatch(samplePassword)).toBe(true);
     });
 
     it('returns false for an expected password mismatch', () => {
-      const user = new User();
       user.encryptedPassword = sampleEncryptedPassword;
       expect(user.isPasswordMatch(nonMatchingPassword)).toBe(false);
+    });
+  });
+
+  describe('#validateInstance', () => {
+    describe('when email is invalid', () => {
+      const invalidValues = [
+        undefined,
+        null,
+        "That's no email!",
+      ];
+
+      invalidValues.forEach((invalidValue) => {
+        it(`throws an error when email is: ${invalidValue} (${typeof (invalidValue)})`, async () => {
+          // @ts-ignore - Force typescript to allow assignment of any test value here
+          user.email = invalidValue;
+          await expect(user.validateInstance()).rejects.toThrow(InvalidEntityException);
+        });
+      });
+    });
+  });
+
+  describe('when a user is deleted', () => {
+    beforeEach(async () => {
+      user.cats = buildSampleCats();
+      await usersService.create(user);
+    });
+
+    it('automatically deletes all associated cats', async () => {
+      const foundCats = await catsService.findAll();
+      expect(foundCats.length).toBeGreaterThan(0);
+      expect(foundCats.map((cat) => cat.id).sort()).toEqual(user.cats.map((cat) => cat.id).sort());
+      await usersService.delete(user.id);
+      expect(await catsService.findAll()).toHaveLength(0);
     });
   });
 });

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -5,7 +5,7 @@ import {
   IsEmail, IsNotEmpty, IsString, Length, MaxLength, validate,
 } from 'class-validator';
 import {
-  BeforeInsert, BeforeUpdate, Column, Entity, Index, ObjectIdColumn, OneToMany, PrimaryGeneratedColumn,
+  Column, Entity, Index, ObjectIdColumn, OneToMany, PrimaryGeneratedColumn,
 } from 'typeorm';
 import { InvalidEntityException } from '../../app/exceptions/invalid-entity.exception';
 // eslint-disable-next-line import/no-cycle
@@ -20,8 +20,6 @@ export interface UserOptions {
 
 @Entity()
 export class User {
-  @BeforeInsert()
-  @BeforeUpdate()
   async validateInstance() {
     const validationErrors = await validate(this);
     if (validationErrors.length) {
@@ -58,8 +56,8 @@ export class User {
   @IsNotEmpty()
   isAdmin: boolean;
 
-  @OneToMany(() => Cat, (cat) => cat.user)
-  cats: Promise<Cat[]>;
+  @OneToMany(() => Cat, (cat) => cat.user, { cascade: true })
+  cats: Cat[];
 
   setPassword(password: string, passwordVerification: string) {
     if (password !== passwordVerification) {

--- a/src/users/providers/users.service.ts
+++ b/src/users/providers/users.service.ts
@@ -1,37 +1,58 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { EntityCreationError, EntityUpdateError } from '../../errors/errors';
 import { User } from '../entities/user.entity';
 
 @Injectable()
 export class UsersService {
   constructor(@InjectRepository(User) private userRepository: Repository<User>) {}
 
-  async findAll(): Promise<User[]> {
-    return this.userRepository.find({ order: { id: 'ASC' } });
+  async findAll(includeCats: boolean = false): Promise<User[]> {
+    return this.userRepository.find({
+      order: { id: 'ASC' },
+      relations: includeCats ? ['cats'] : undefined,
+    });
   }
 
-  async find(id: number): Promise<User> {
-    return this.userRepository.findOne(id);
+  async find(id: number, includeCats: boolean = false): Promise<User> {
+    return this.userRepository.findOne(id, {
+      relations: includeCats ? ['cats'] : undefined,
+    });
   }
 
-  async findByEmail(email: string): Promise<User> {
-    return this.userRepository.findOne({ where: { email } });
+  async findByEmail(email: string, includeCats: boolean = false): Promise<User> {
+    return this.userRepository.findOne({
+      where: { email },
+      relations: includeCats ? ['cats'] : undefined,
+    });
   }
 
   async exists(id: number): Promise<boolean> {
     return (await this.find(id)) !== undefined;
   }
 
-  async save(user: User): Promise<User> {
+  async create(user: User): Promise<User> {
+    if (user.id) {
+      throw new EntityCreationError('Not allowed to specify an id for a new user.');
+    }
+    await user.validateInstance();
+    return this.userRepository.save(user);
+  }
+
+  async update(user: User): Promise<User> {
+    if (!user.id) {
+      throw new EntityUpdateError('Unable to update a user without an id.');
+    }
+    await user.validateInstance();
     return this.userRepository.save(user);
   }
 
   async delete(id: number) {
-    this.userRepository.delete(id);
+    await this.userRepository.delete(id);
   }
 
   async deleteAll() {
-    this.userRepository.clear();
+    await this.userRepository.clear();
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,10 +1,10 @@
+/* eslint-disable class-methods-use-this */
 import {
   Body, ClassSerializerInterceptor, Controller, Delete, Get, HttpCode,
-  HttpException, HttpStatus, Param, Patch, Post, Put, UseGuards, UseInterceptors,
+  HttpException, HttpStatus, Param, Patch, Post, UseGuards, UseInterceptors,
 } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { PatchUserDto } from './dto/patch-user.dto';
-import { ReplaceUserDto } from './dto/replace-user.dto';
 import { User } from './entities/user.entity';
 import { AdminGuard } from './guards/admin.guard';
 import { UsersService } from './providers/users.service';
@@ -34,24 +34,7 @@ export class UsersController {
     const { password, passwordVerification, ...otherFields } = dto;
     const user: User = new User(otherFields);
     user.setPassword(password, passwordVerification);
-    return this.usersService.save(user);
-  }
-
-  @Put(':id')
-  async replace(@Param('id') id: number, @Body() dto: ReplaceUserDto): Promise<User> {
-    if (!(await this.usersService.exists(id))) {
-      throw new HttpException('Not found', HttpStatus.NOT_FOUND);
-    }
-
-    if (!Object.keys(dto).length) {
-      throw new HttpException('At least one valid property is required for an update.', HttpStatus.BAD_REQUEST);
-    }
-
-    const { password, passwordVerification, ...otherFields } = dto;
-    const user: User = new User(otherFields);
-    user.id = id;
-    user.setPassword(password, passwordVerification);
-    return this.usersService.save(user);
+    return this.usersService.create(user);
   }
 
   @Patch(':id')
@@ -62,7 +45,7 @@ export class UsersController {
     if (password) {
       user.setPassword(password, passwordVerification);
     }
-    return this.usersService.save(user);
+    return this.usersService.update(user);
   }
 
   @Delete(':id')

--- a/test/e2e/app.e2e-spec.ts
+++ b/test/e2e/app.e2e-spec.ts
@@ -7,10 +7,12 @@ import { AppModule } from '../../src/app/app.module';
 import { createTestUser, testUserEmail, testUserPassword } from '../helpers/authenticationHelpers';
 import { clearAllTables } from '../helpers/repositoryHelpers';
 import { User } from '../../src/users/entities/user.entity';
+import { UsersService } from '../../src/users/providers/users.service';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
   let userRepository: Repository<User>;
+  let usersService: UsersService;
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -21,11 +23,12 @@ describe('AppController (e2e)', () => {
     await app.init();
 
     userRepository = moduleRef.get<Repository<User>>(getRepositoryToken(User));
+    usersService = moduleRef.get<UsersService>(UsersService);
   });
 
   beforeEach(async () => {
     await clearAllTables(userRepository.manager.connection);
-    await createTestUser(userRepository);
+    await createTestUser(usersService);
   });
 
   it('/ (GET)', () => {

--- a/test/helpers/authenticationHelpers.ts
+++ b/test/helpers/authenticationHelpers.ts
@@ -1,5 +1,5 @@
-import { Repository } from 'typeorm';
 import { User } from '../../src/users/entities/user.entity';
+import { UsersService } from '../../src/users/providers/users.service';
 
 export const testUserEmail = 'user@example.com';
 export const testUserPassword = 'userpassword';
@@ -7,14 +7,14 @@ export const testUserPassword = 'userpassword';
 export const testAdminEmail = 'admin@example.com';
 export const testAdminPassword = 'adminpassword';
 
-export const createTestUser = async (userRespository: Repository<User>) => {
+export const createTestUser = async (usersService: UsersService) => {
   const user = new User({ email: testUserEmail, isAdmin: false });
   user.setPassword(testUserPassword, testUserPassword);
-  return userRespository.save(user);
+  return usersService.create(user);
 };
 
-export const createTestAdmin = async (userRespository: Repository<User>) => {
+export const createTestAdmin = async (usersService: UsersService) => {
   const user = new User({ email: testAdminEmail, isAdmin: true });
   user.setPassword(testAdminPassword, testAdminPassword);
-  return userRespository.save(user);
+  return usersService.create(user);
 };

--- a/test/helpers/catHelpers.ts
+++ b/test/helpers/catHelpers.ts
@@ -1,0 +1,34 @@
+import { Cat } from '../../src/cats/entities/cat.entity';
+import { User } from '../../src/users/entities/user.entity';
+
+export const sampleCatOptions = [
+  {
+    name: 'Cat-man Dude', breed: 'Half-Man Half-Cat', weight: 170, isFriendly: true,
+  },
+  {
+    name: 'Falafel', weight: 10, breed: 'British Shorthair', isFriendly: true,
+  },
+  {
+    name: 'Garfield', weight: 30, breed: 'Tabby', isFriendly: false,
+  },
+];
+
+export const buildSampleCats = (user: User = null) => {
+  return sampleCatOptions.map((catData) => {
+    const cat = new Cat(catData);
+    if (user) { cat.user = user; }
+    return cat;
+  });
+};
+
+export const buildSampleCat = (user: User = null) => {
+  const cat = new Cat(sampleCatOptions[0]);
+  if (user) { cat.user = user; }
+  return cat;
+};
+
+export const catToPojoWithoutUser = (cat: Cat) => {
+  const pojoCat = { ...cat };
+  delete pojoCat.user;
+  return pojoCat;
+};

--- a/test/helpers/userHelpers.ts
+++ b/test/helpers/userHelpers.ts
@@ -1,5 +1,12 @@
 import { User } from '../../src/users/entities/user.entity';
 
+interface SampleUserOptions {
+  email: string,
+  password: string,
+  passwordVerification: string,
+  isAdmin: boolean,
+}
+
 const sourceUserData = [
   {
     email: 'user1@example.com', password: 'greatpassword1', passwordVerification: 'greatpassword1', isAdmin: false,
@@ -12,13 +19,19 @@ const sourceUserData = [
   },
 ];
 
-export const generateSampleUsers = () => {
-  return sourceUserData.map((userData) => {
-    const { password, passwordVerification, ...otherUserFields } = userData;
-    const user = new User(otherUserFields);
-    user.setPassword(password, passwordVerification);
-    return user;
-  });
+export const buildUser = (userData: SampleUserOptions) => {
+  const { password, passwordVerification, ...otherUserFields } = userData;
+  const user = new User(otherUserFields);
+  user.setPassword(password, passwordVerification);
+  return user;
+};
+
+export const buildSampleUsers = () => {
+  return sourceUserData.map(buildUser);
+};
+
+export const buildSampleUser = () => {
+  return buildUser(sourceUserData[0]);
 };
 
 export const userToPojoWithoutPassword = (user: User) => {


### PR DESCRIPTION
- CatsController#create automatically assigns the current user to the created Cat
- No longer lazily loading Cat and User relationships
- In CatsService, added optional parameter to include User when finding Cats
- Replaced CatsService#save with CatsService#create and CatsService#update
- In UsersService, added optional parameter to include Cats when finding Users
- Replaced UsersService#save with UsersService#create and UsersService#update
- Deleting a User automatically deletes its Cats
- Entity validation is now performed on the service level
- Removed PUT /cats/:id and /users/:id routes
- Added catHelpers.ts and updated userHelpers.ts
- Added Cat, User, and UsersService tests